### PR TITLE
fix if condition in Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST =	COPYING INSTALL install-sh \
 		matrix.psf.gz mtx.pcf cmatrix.1 cmatrix.spec
 
 install-data-local:
-	if test $(BUILD_FONTS) = 1; then \
+	@if test $(BUILD_FONTS) = 1; then \
 		if test -d /usr/share/consolefonts; then \
 	    		echo " Installing matrix fonts in /usr/share/consolefonts..."; \
 	    		$(INSTALL_DATA) $(srcdir)/matrix.fnt /usr/share/consolefonts; \

--- a/Makefile.in
+++ b/Makefile.in
@@ -837,7 +837,7 @@ uninstall-man: uninstall-man1
 
 
 install-data-local:
-	if test $(BUILD_FONTS) = 1; then \
+	@if test $(BUILD_FONTS) = 1; then \
 		if test -d /usr/share/consolefonts; then \
 	    		echo " Installing matrix fonts in /usr/share/consolefonts..."; \
 	    		$(INSTALL_DATA) $(srcdir)/matrix.fnt /usr/share/consolefonts; \


### PR DESCRIPTION
The outermost if condition in the Makefile requires to be prefixed with a @ symbol.
`make` simply prints out the entire function even though it executes the function fine.

This resolves point 1 in https://github.com/abishekvashok/cmatrix/issues/9#issuecomment-320709647.