### PR TITLE
Travis: also test-compile with CLang (not just with GCC)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ os: linux
 
 sudo: required
 
-compiler: gcc
+compiler:
+  - gcc
+  - clang
 
 script:
   - ./configure


### PR DESCRIPTION
CLang is a more modular, more recent native compiler suite; alternative to GCC.