### PR TITLE
Removes "./" from the commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ You'll probably need a decent ncurses library to get this to work.
 ### Installing cmatrix
 To install cmatrix, in the cmatrix directory run:
 - `./configure`
-- `./make`
-- `./make install`
+- `make`
+- `make install`
 
 ### Running cmatrix
 After you have installed cmatrix just run `cmatrix` to run cmatrix :)


### PR DESCRIPTION
If a user tries to run the commands as it is given, it throws an error. 
bash: ./make: No such file or directory

It is obvious among normal users, but could help a lesser experienced user.