### PR TITLE
Fix signal handlers and memory related bugs

### DIFF
--- a/cmatrix.c
+++ b/cmatrix.c
@@ -170,9 +170,10 @@ void var_init(void) {
         free(matrix);
     }
 
-    matrix = nmalloc(sizeof(cmatrix) * (LINES + 1));
-    for (i = 0; i <= LINES; i++) {
-        matrix[i] = nmalloc(sizeof(cmatrix) * COLS);
+    matrix = nmalloc(sizeof(cmatrix *) * (LINES + 1));
+    matrix[0] = nmalloc(sizeof(cmatrix) * (LINES + 1) * COLS);
+    for (i = 1; i <= LINES; i++) {
+        matrix[i] = matrix[i - 1] + COLS;
     }
 
     if (length != NULL) {

--- a/cmatrix.c
+++ b/cmatrix.c
@@ -196,6 +196,16 @@ void var_init(void) {
     for (i = 0; i <= LINES; i++) {
         for (j = 0; j <= COLS - 1; j += 2) {
             matrix[i][j].val = -1;
+            /* I couldn't quite get how the bold attribute is used in the code,
+             * but it is used uninitialized later on (according to Valgrind and
+             * my manual inspection). I guess the default value should be 0,
+             * as setting it does not change the observable behaviour and shuts
+             * Valgrind up. Also, the code seems to expect a value of 0,
+             * although I'm not quite sure about that.
+             * In any case, there is an uninitialized use,
+             * so some default value should be set here (whatever it is).
+             */
+            matrix[i][j].bold = 0;
         }
     }
 

--- a/cmatrix.c
+++ b/cmatrix.c
@@ -167,6 +167,7 @@ void var_init(void) {
     int i, j;
 
     if (matrix != NULL) {
+        free(matrix[0]);
         free(matrix);
     }
 


### PR DESCRIPTION
By running the program in Valgrind and inspecting the code visually, I have uncovered some memory related bugs. I belive this set of commits fixes those bugs. These bugs were:

- Memory leak on screen resize. The matrix was not properly freed in the var_init() function, so each time the screen is resized, some amount of memory was leaked.
- Uninitialized use of matrix attribute bold. The bold attribute of the matrix cells was not initialized anywhere in the code. I initialized them to 0 in var_init(). Although I'm not sure what the default value should be, some value must be set somewhere.
- Wrong sizeof in matrix allocation. The Matrix, which contains pointers to rows of `struct cmatrix`, was allocated with `sizeof(cmatrix)`, as `matrix = nmalloc(sizeof(cmatrix) * (LINES + 1));`. This did not cause a problem because, by coincidence, the struct contained two `int`s which in total have the size of a pointer. I fixed that allocation, and also improved the allocation strategy by allocating all the rows at once, making the free'ing logic simpler and more efficient.

Also, I've noticed that the signal handlers called non signal-safe functions, which poses some serious problems if multiple `SIGWINCH`es arrived within short intervals. To observe the problematic behaviour, one can resize the terminal multiple times very quickly. This generally leads to a segmentation fault. I fixed this by making the signal handler set a global variable to indicate the signal, and checking this variable at each iteration of the main loop and taking the appropriate action.