### PR TITLE
Fix two small warnings

### DIFF
--- a/cmatrix.c
+++ b/cmatrix.c
@@ -76,12 +76,13 @@ volatile sig_atomic_t signal_status = 0; /* Indicates a caught signal */
 int va_system(char *str, ...) {
 
     va_list ap;
-    char foo[133];
+    static const unsigned int buf_size = 133;
+    char buf[buf_size];
 
     va_start(ap, str);
-    vsnprintf(foo, 132, str, ap);
+    vsnprintf(buf, buf_size - 1, str, ap);
     va_end(ap);
-    return system(foo);
+    return system(buf);
 }
 
 /* What we do when we're all set to exit */

--- a/cmatrix.c
+++ b/cmatrix.c
@@ -233,7 +233,7 @@ void sighandler(int s) {
 }
 
 void resize_screen(void) {
-    char *tty = NULL;
+    char *tty;
     int fd = 0;
     int result = 0;
     struct winsize win;


### PR DESCRIPTION
these were found using a recent version of `cppcheck`

* replace 2 related constant values with a single const variable, which prevents accidental change of one value, forgetting the other
* removes one unused value

... i am not angry if you consider this too unimportant. ;-)