### PR TITLE
Only restores TERM when it's changed.

### DIFF
--- a/cmatrix.c
+++ b/cmatrix.c
@@ -297,7 +297,7 @@ int main(int argc, char *argv[]) {
     int pause = 0;
 
     char *oldtermname;
-    char *syscmd = NULL;
+    char *oldterm = NULL;
 
     time_t t;
     srand((unsigned) time(&t));
@@ -745,9 +745,11 @@ if (console) {
         }
         napms(update * 10);
     }
-    syscmd = nmalloc(sizeof (char *) * (strlen(oldtermname) + 15));
-    sprintf(syscmd, "putenv TERM=%s", oldtermname);    
-    system(syscmd);
+    if (force && strcmp(oldtermname, getenv("TERM"))) {
+        oldterm = nmalloc(sizeof (char *) * (strlen(oldtermname) + 6));
+        sprintf(oldterm, "TERM=%s", oldtermname);
+        putenv(oldterm);
+    }
     finish();
 }
 


### PR DESCRIPTION
I'd like to switch to `setenv`, but I think that requires @abishekvashok's approval, I'd add another commit, if it's okay to switch.

I think the following comment might be outdated (no idea when it was commented):

https://github.com/abishekvashok/cmatrix/blob/5cfe816849042a380c387fd4efa1d475f1fdf210/cmatrix.c#L387-L391

From manpage of `setenv(3)`, it conforms to  POSIX.1-2001, POSIX.1-2008, 4.3BSD, they were long ago, not sure if that statement in the comment still stands in the current status.

There are a few pages about `putenv` and `setenv`: [1][1], [2][2], [3][3].

[1]: https://www.greenend.org.uk/rjk/tech/putenv.html
[2]: https://stackoverflow.com/questions/5873029/questions-about-putenv-and-setenv
[3]: https://stackoverflow.com/questions/45938604/why-was-getenv-standardised-but-not-setenv