### PR TITLE
remove the "132x300" screen limit statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # CMatrix
 
 CMatrix is based on the screensaver from The Matrix website. It shows text
-flying in and out in a terminal like as seen in "The Matrix" movie. It works
-with terminal settings up to 132x300 and can scroll lines all at the same
-rate or asynchronously and at a user-defined speed.
+flying in and out in a terminal like as seen in "The Matrix" movie. It can
+scroll lines all at the same rate or asynchronously and at a user-defined
+speed.
 
 CMatrix by default operates in **eye candy** mode.  It must be aborted with
 control-c (Ctrl+C) or by pressing q.  If you wish for more of a screen saver

--- a/cmatrix.spec.in
+++ b/cmatrix.spec.in
@@ -16,9 +16,8 @@ Requires: ncurses
 Conflicts: none
 BuildRoot: /var/tmp/%{name}-buildroot
 %Description
-CMatrix is based on the screensaver from The Matrix website. It works
-with terminal settings up to 132x300 and can scroll lines all at the same
-rate or asynchronously and at a user-defined speed.
+CMatrix is based on the screensaver from The Matrix website. It can scroll
+lines all at the same rate or asynchronously and at a user-defined speed.
 %Prep
 %setup
 %Build


### PR DESCRIPTION
Which isn't true (anymore?), it all depends on the terminal emulator and ncurses, and practically the CPU processing power.

See also GH #18.