### PR TITLE
Temporary solution for #83 to allow for use of config.h with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,16 @@ set(X_FONTS_DIRS "lib/X11/fonts/misc" "X11R6/lib/X11/fonts/misc" "share/fonts/X1
 
 set(MKFONTDIR "/usr/bin/mkfontdir")
 
-add_definitions(-DEXCLUDE_CONFIG_H)
+message(STATUS "Looking for include file config.h")
+if(NOT EXISTS "${CMAKE_SOURCE_DIR}/config.h")
+    add_definitions(-DEXCLUDE_CONFIG_H)
+    message(STATUS "Looking for include file config.h - missing")
+else()
+    message(STATUS "Looking for include file config.h - found")
+endif()
+
+# configure_file(config.h.in config.h)
+
 add_definitions(-DVERSION="${VERSION}")
 add_definitions(-DUSE_TIOCSTI)
 


### PR DESCRIPTION
This commit provides a temporary fix for #83 that caused cmatrix to add a background color, instead of using the default terminal background. This issue is only present in cmake builds.

CMakeLists.txt now checks to see if a `config.h` is present. If a `config.h` is not available, it will add the preprocessor definition EXCLUDE_CONFIG_H as it has prior. However, if a config.h is present, we will use that instead. This allows a user to run `autoreconf -i && ./configure` before running `cmake` and finally, `make`.

If this fix is accepted, I would recommend adding those	to the build instructions in the README. Ideally, CMake should be able to make the `config.h` for us, but some work will need to be done to ensure it matches what autotools would output.

On a slightly personal note, this will also require an update to the [PKGBUILD](https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/cmatrix) ([AUR](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=cmatrix-git)) neither of which appear to be a separate branch available for editing. :)

Let me know what more I can do to help!