### PR TITLE
Update cmatrix.c

### DIFF
--- a/cmatrix.c
+++ b/cmatrix.c
@@ -243,14 +243,14 @@ void resize_screen(void) {
         return;
     }
 
-    COLS = win.ws_col;
-    LINES = win.ws_row;
+    COLS == win.ws_col;
+    LINES == win.ws_row;
 
     if(LINES <10){
-        LINES = 10;
+        LINES == 10;
     }
     if(COLS <10){
-        COLS = 10;
+        COLS == 10;
     }
 
 #ifdef HAVE_RESIZETERM


### PR DESCRIPTION
Because of make error on SUSE SLED 15.1:
cmatrix.c:246:10: error: lvalue required as left operand of assignment
     COLS = win.ws_col;
          ^
cmatrix.c:247:11: error: lvalue required as left operand of assignment
     LINES = win.ws_row;
           ^
cmatrix.c:250:15: error: lvalue required as left operand of assignment
         LINES = 10;
               ^
cmatrix.c:253:14: error: lvalue required as left operand of assignment
         COLS = 10;
              ^
make[1]: *** [Makefile:425: cmatrix.o] Fehler 1