### PR TITLE
Add option to choose tty

### DIFF
--- a/cmatrix.1
+++ b/cmatrix.1
@@ -50,6 +50,8 @@ Screen update delay 0 - 9, default 4
 .I "\-C color"
 Use this color for matrix (default green). 
 Valid colors are green, red, blue, white, yellow, cyan, magenta and black.
+.I "\-t tty"
+Set tty to use
 .SS KEYSTROKES
 The following keystrokes are available during execution (unavailable in
 \-s mode)


### PR DESCRIPTION
This patch allows choosing the tty to use with the `-t` flag. I intend this to be more usable as a screensaver for VTs (`/dev/tty{1..6}`)