### PR TITLE
Update cmatrix.c

### DIFF
--- a/cmatrix.c
+++ b/cmatrix.c
@@ -274,15 +274,15 @@ void resize_screen(void) {
         return;
     }
 
-    COLS = win.ws_col;
-    LINES = win.ws_row;
+    COLS == win.ws_col;
+    LINES == win.ws_row;
 #endif
 
     if(LINES <10){
-        LINES = 10;
+        LINES == 10;
     }
     if(COLS <10){
-        COLS = 10;
+        COLS == 10;
     }
 
 #ifdef HAVE_RESIZETERM


### PR DESCRIPTION
gcc compile error fixed.

gcc -DHAVE_CONFIG_H -I.     -g -O2 -MT cmatrix.o -MD -MP -MF .deps/cmatrix.Tpo -c -o cmatrix.o cmatrix.c
cmatrix.c: In function ‘resize_screen’:
cmatrix.c:277:10: error: lvalue required as left operand of assignment
     COLS = win.ws_col;
          ^
cmatrix.c:278:11: error: lvalue required as left operand of assignment
     LINES = win.ws_row;
           ^
cmatrix.c:282:15: error: lvalue required as left operand of assignment
         LINES = 10;
               ^
cmatrix.c:285:14: error: lvalue required as left operand of assignment
         COLS = 10;