### PR TITLE
Fix unicode character printing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ if	(HAVE_GETOPT_H)
 endif	()
 
 Set(CURSES_NEED_NCURSES TRUE)
+Set(CURSES_NEED_WIDE TRUE)
 find_package(Curses)
 include_directories(${CURSES_INCLUDE_DIR})
 add_definitions(-DHAVE_NCURSES_H)

--- a/cmatrix.c
+++ b/cmatrix.c
@@ -514,8 +514,8 @@ if (console) {
          * they appear alongside latin characters and numerals, but this is the
          * closest we can do with a standard unicode set and a single number
          * range */
-        randmin = 0xff61;
-        highnum = 0xff9e;
+        randmin = 0xff66;
+        highnum = 0xff9d;
     } else if (console || xwindow) {
         randmin = 166;
         highnum = 217;

--- a/cmatrix.c
+++ b/cmatrix.c
@@ -21,6 +21,8 @@
 
 */
 
+#define NCURSES_WIDECHAR 1
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -508,9 +510,12 @@ if (console) {
 
     /* Set up values for random number generation */
     if(classic) {
-        /* Japanese character unicode range [they are seen in the original cmatrix] */
-        randmin = 12288;
-        highnum = 12351;
+        /* Half-width kana characters. In the movie they are y-axis flipped, and
+         * they appear alongside latin characters and numerals, but this is the
+         * closest we can do with a standard unicode set and a single number
+         * range */
+        randmin = 0xff61;
+        highnum = 0xff9e;
     } else if (console || xwindow) {
         randmin = 166;
         highnum = 217;
@@ -819,7 +824,15 @@ if (console) {
                         } else if (lambda && matrix[i][j].val != ' ') {
                             addstr("λ");
                         } else {
-                            addch(matrix[i][j].val);
+                            /* addch doesn't seem to work with unicode
+                             * characters and there was no direct equivalent.
+                             * So, construct a c-style string with the character
+                             * and print that.
+                             */
+                            wchar_t char_array[2];
+                            char_array[0] = matrix[i][j].val;
+                            char_array[1] = 0;
+                            addwstr(char_array);
                         }
                         if (bold == 2 ||
                             (bold == 1 && matrix[i][j].val % 2 == 0)) {


### PR DESCRIPTION
EDIT: to clarify, this is concerning the `-c` option.

Fix several issues that prevented it from working

  * link to the wide-character version of ncurses
  * define NCURSES_WIDECHAR
  * use a function that can print wide characters
  * fix the character range. I don't know what the original was supposed
    to be, but half-width kana (which is what the movie reportedly used)
    was not at that range.

Tested this on arch linux with
  * gcc 10.2.0
  * ncurses 6.2
  * glibc 2.32

It would be great if others could try it out on different setups so we can see how it works.