### PR TITLE
docs: fix simple typo, collumn -> column

### DIFF
--- a/cmatrix.c
+++ b/cmatrix.c
@@ -658,7 +658,7 @@ if (console) {
                             spaces[j]--;
                         } else {
 
-                            /* Random number to determine whether head of next collumn
+                            /* Random number to determine whether head of next column
                                of chars has a white 'head' on it. */
 
                             if (((int) rand() % 3) == 1) {
@@ -700,7 +700,7 @@ if (console) {
                             break;
                         }
 
-                        /* Go to the head of this collumn */
+                        /* Go to the head of this column */
                         z = i;
                         y = 0;
                         while (i <= LINES && (matrix[i][j].val != ' ' &&
@@ -722,7 +722,7 @@ if (console) {
                         matrix[i][j].val = (int) rand() % randnum + randmin;
                         matrix[i][j].is_head = true;
 
-                        /* If we're at the top of the collumn and it's reached its
+                        /* If we're at the top of the column and it's reached its
                            full length (about to start moving down), we do this
                            to get it moving.  This is also how we keep segments not
                            already growing from growing accidentally =>


### PR DESCRIPTION
There is a small typo in cmatrix.c.

Should read `column` rather than `collumn`.

