### PR TITLE
Fixes #98: Don't try to print non-printable chars

### DIFF
--- a/cmatrix.c
+++ b/cmatrix.c
@@ -194,6 +194,14 @@ void var_init() {
         matrix[i] = matrix[i - 1] + COLS;
     }
 
+    for (i = 0; i < LINES; ++i)
+    {
+        for (j = 0; j < COLS; ++j)
+        {
+            matrix[i][j].is_head = false;
+        }
+    }
+
     if (length != NULL) {
         free(length);
     }

--- a/cmatrix.c
+++ b/cmatrix.c
@@ -194,14 +194,6 @@ void var_init() {
         matrix[i] = matrix[i - 1] + COLS;
     }
 
-    for (i = 0; i < LINES; ++i)
-    {
-        for (j = 0; j < COLS; ++j)
-        {
-            matrix[i][j].is_head = false;
-        }
-    }
-
     if (length != NULL) {
         free(length);
     }
@@ -769,6 +761,8 @@ if (console) {
                         } else {
                             addch('&');
                         }
+                    } else if (matrix[i][j].val == -1) {
+                        addch(' ');
                     } else {
                         addch(matrix[i][j].val);
                     }


### PR DESCRIPTION
This lead to unintended consequences as random block of characters
appeared on resizing when we tried to pass non printable -1 to addch.
Introduces a simple if statement to fix it.

Here's a gif:

![](https://im6.ezgif.com/tmp/ezgif-6-cdb4275d1d6d.gif)

