### PR TITLE
Reset TERM variable on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ cscope.in.out
 cscope.po.out
 cscope.files
 cmatrix
+cmatrix.exe
 *.o
 *.core
 CMakeCache.txt

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ effect, you must specify `-s` on the command line. For usage info, use `cmatrix 
 [![Build Status](https://travis-ci.org/abishekvashok/cmatrix.svg?branch=master)](https://travis-ci.org/abishekvashok/cmatrix)
 
 ### Dependencies
-You'll probably need a decent ncurses library (or PDCurses on native Windows) to get this to work.
+You'll probably need a decent ncurses library to get this to work. On Windows, using mingw-w64-ncurses is recommended (PDCurses will also work, but it does not support colors or bold text).
 
 ### Building and installing cmatrix
 To install cmatrix, use either of the following methods from within the cmatrix directory.
 
-#### Using `configure` (recommended for most linux user)
-```
+#### Using `configure` (recommended for most linux/mingw users)
+```shell
 autoreconf -i  # skip if using released tarball
 ./configure
 make
@@ -27,8 +27,8 @@ make install
 
 #### Using CMake
 Here we also show an out-of-source build in the sub directory "build".
-Don't use CMake if you want to use PDCurses, it won't work (for now).
-```
+(Doesn't work on Windows, for now).
+```shell
 mkdir -p build
 cd build
 # to install to "/usr/local"

--- a/cmatrix.c
+++ b/cmatrix.c
@@ -48,7 +48,11 @@
 #ifdef HAVE_NCURSES_H
 #include <ncurses.h>
 #else
+#ifdef _WIN32
+#include <ncurses/curses.h>
+#else
 #include <curses.h>
+#endif
 #endif
 
 #ifdef HAVE_SYS_IOCTL_H
@@ -420,6 +424,11 @@ int main(int argc, char *argv[]) {
             break;
         }
     }
+
+    /* Clear TERM variable on Windows */
+#ifdef _WIN32
+    _putenv_s("TERM", "");
+#endif
 
     if (force && strcmp("linux", getenv("TERM"))) {
 #ifdef _WIN32

--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,11 @@ if test "$ac_cv_prog_CC" = gcc -o "$ac_cv_prog_CC" = g++; then
   CFLAGS="$CFLAGS -Wall -Wno-comment"
 fi
 
+dnl Build static executable on native Windows
+if test x$native_windows != xno; then
+  CFLAGS="$CFLAGS -static"
+fi
+
 dnl cmatrix terminal font disable option (default enabled)
 AC_ARG_WITH([fonts],
 	AS_HELP_STRING([--without-fonts], [Install cmatrix without cmatrix font]),


### PR DESCRIPTION
This follows the discussion in the issue thread here: https://github.com/abishekvashok/cmatrix/issues/40#issuecomment-907739880

The current instructions in the Readme result in an executable that has a runtime dependency on `libwinpthread-1.dll` on Windows. This can be rectified by passing `-static` as a compiler flag to the configure script, like this:
```shell
./configure CFLAGS=-static
```

Should I add this info to the Readme?