### PR TITLE
Fix `‘TIOCSTI’ undeclared` error on MSYS2

### DIFF
--- a/cmatrix.c
+++ b/cmatrix.c
@@ -69,6 +69,10 @@
 #include <termio.h>
 #endif
 
+#ifdef __CYGWIN__
+#define TIOCSTI 0x5412
+#endif
+
 /* Matrix typedef */
 typedef struct cmatrix {
     int val;


### PR DESCRIPTION
This value seems to be undefined in MSYS2 environments.

Needs to be manually defined. 

Reference - https://github.com/dvorka/hstr/commit/79781c138b972f553303d2b6d045ae215391a014