### PR TITLE
Also allow for X11 fonts in /usr/share/X11/fonts/misc as well

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,14 @@ install-data-local:
 	    		$(INSTALL_DATA) $(srcdir)/mtx.pcf $(DESTDIR)/usr/share/fonts/misc; \
 	    		echo " Done.  If this is the first time you have installed CMatrix you will"; \
 	    		echo " probably have to restart X window in order to use the mtx.pcf font."; \
+		elif test -d /usr/share/X11/fonts/misc; then \
+	    		echo " Installing X window matrix fonts in /usr/share/X11/fonts/misc..."; \
+	    		echo " Running mkfontdir /usr/share/X11/fonts/misc..."; \
+	    		$(MKFONTDIR) $(DESTDIR)/usr/share/X11/fonts/misc; \
+	    		$(INSTALL_DATA) $(srcdir)/mtx.pcf $(DESTDIR)/usr/share/X11/fonts/misc; \
+	    		$(INSTALL_DATA) $(srcdir)/mtx.pcf $(DESTDIR)/usr/share/X11/fonts/misc; \
+	    		echo " Done.  If this is the first time you have installed CMatrix you will"; \
+	    		echo " probably have to restart X window in order to use the mtx.pcf font."; \
 		else \
 			if test -d /usr/X11R6/lib/X11/fonts/misc; then \
 	    			echo " Installing X window matrix fonts in /usr/X11R6/lib/X11/fonts/misc..."; \

--- a/configure.ac
+++ b/configure.ac
@@ -134,7 +134,7 @@ if test "x$enable_fonts" != xfalse; then
   fi
 
   AC_PATH_PROG(MKFONTDIR, mkfontdir, "", $PATH:/usr/bin:/usr/bin/X11:/usr/local/bin/X11:/usr/X11R6/bin:/usr/local/bin:/sbin:/usr/sbin)
-  AC_CHECK_FILES([/usr/share/fonts/misc /usr/X11R6/lib/X11/fonts/misc])
+  AC_CHECK_FILES([/usr/share/fonts/misc /usr/share/X11/fonts/misc /usr/X11R6/lib/X11/fonts/misc])
 
   if test "x$ac_cv_file__usr_lib_X11_fonts_misc" = "xno"; then
       if test "x$ac_cv_file__usr_X11R6_lib_X11_fonts_misc" = "xno"; then


### PR DESCRIPTION
This is the fonts directory used in Fedora and Red Hat Enterprise Linux
and derivatives:

https://src.fedoraproject.org/rpms/xorg-x11-fonts/blob/rawhide/f/xorg-x11-fonts.spec#_3

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>