### PR TITLE
Install man page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ add_executable(cmatrix cmatrix.c)
 
 target_link_libraries(cmatrix ${CURSES_LIBRARIES})
 
-install(TARGETS cmatrix DESTINATION bin)
+install(TARGETS cmatrix DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES cmatrix.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
 if     (UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_minimum_required(VERSION 2.8)
 project(CMatrix LANGUAGES C)
 set(VERSION "2.0")
 
+include(GNUInstallDirs)
+
 # These are relative to CMAKE_INSTALL_PREFIX
 # which by default is "/usr/local"
 set(CONSOLE_FONTS_DIRS "share/consolefonts" "lib/kbd/consolefonts")
@@ -59,6 +61,7 @@ add_executable(cmatrix cmatrix.c)
 target_link_libraries(cmatrix ${CURSES_LIBRARIES})
 
 install(TARGETS cmatrix DESTINATION bin)
+install(FILES cmatrix.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
 if     (UNIX)
 	foreach    (CONSOLE_FONTS_DIR ${CONSOLE_FONTS_DIRS})


### PR DESCRIPTION
Use `GNUInstallDirs` to provide the install location.

Also while I was at it, install binary to the path provided by `GNUInstallDirs` (defaults to `bin` which is the same; this allows overriding, though)