### PR TITLE
Add check for use_default_colors to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,13 @@ find_package(Curses)
 include_directories(${CURSES_INCLUDE_DIR})
 add_definitions(-DHAVE_NCURSES_H)
 
+include(CheckSymbolExists)
+list(APPEND CMAKE_REQUIRED_LIBRARIES ncurses)
+check_symbol_exists(use_default_colors "ncurses.h" HAVE_USE_DEFAULT_COLORS)
+if (HAVE_USE_DEFAULT_COLORS)
+    add_definitions(-DHAVE_USE_DEFAULT_COLORS)
+endif()
+
 add_executable(cmatrix cmatrix.c)
 
 target_link_libraries(cmatrix ${CURSES_LIBRARIES})


### PR DESCRIPTION
Adds a check for the `use_default_colors` function to CMakeLists. This should resolve issues with background color and transparency.

Fixes: #146 