### PR TITLE
waddnwstr fix for #161

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_PROG_MAKE_SET
 
 dnl Checks for libraries.
 dnl Replace `main' with a function in -lncurses:
-AC_CHECK_LIB(ncurses, main)
+AC_CHECK_LIB(ncursesw, waddnwstr)
 
 dnl Checks for header files.
 AC_HEADER_STDC


### PR DESCRIPTION
Fix for #161. Normal ncurses is already checked further below but waddnwstr is part of ncursesw. Without this fix you get a double:
Makefile:
```
LIBS = -lncurses  -lncurses
```

where it should be:
```
LIBS = -lncursesw  -lncurses
```

tested on default Kali install:
```
PRETTY_NAME="Kali GNU/Linux Rolling"
NAME="Kali GNU/Linux"
VERSION_ID="2023.2"
VERSION="2023.2"
VERSION_CODENAME=kali-rolling
ID=kali
ID_LIKE=debian
HOME_URL="https://www.kali.org/"
SUPPORT_URL="https://forums.kali.org/"
BUG_REPORT_URL="https://bugs.kali.org/"
ANSI_COLOR="1;31"
```
