### PR TITLE
Fix compilation error with recent ncurses versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(GNUInstallDirs)
 
 # These are relative to CMAKE_INSTALL_PREFIX
 # which by default is "/usr/local"
-set(CONSOLE_FONTS_DIRS "share/consolefonts" "lib/kbd/consolefonts")
+set(CONSOLE_FONTS_DIRS "share/consolefonts" "lib/kbd/consolefonts" "share/kbd/consolefonts")
 set(X_FONTS_DIRS "lib/X11/fonts/misc" "X11R6/lib/X11/fonts/misc" "share/fonts/X11/misc")
 
 set(MKFONTDIR "/usr/bin/mkfontdir")

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,11 @@ install-data-local:
 	    		$(INSTALL_DATA) $(srcdir)/matrix.fnt $(DESTDIR)/usr/lib/kbd/consolefonts; \
 	    		$(INSTALL_DATA) $(srcdir)/matrix.psf.gz $(DESTDIR)/usr/lib/kbd/consolefonts; \
 		fi; \
+		if test -d /usr/share/kbd/consolefonts; then \
+	    		echo " Installing matrix fonts in /usr/share/kbd/consolefonts..."; \
+	    		$(INSTALL_DATA) $(srcdir)/matrix.fnt $(DESTDIR)/usr/share/kbd/consolefonts; \
+	    		$(INSTALL_DATA) $(srcdir)/matrix.psf.gz $(DESTDIR)/usr/share/kbd/consolefonts; \
+		fi; \
 		if test -d /usr/share/fonts/misc; then \
 	    		echo " Installing X window matrix fonts in /usr/share/fonts/misc..."; \
 	    		echo " Running mkfontdir /usr/share/fonts/misc..."; \

--- a/cmatrix.c
+++ b/cmatrix.c
@@ -47,6 +47,9 @@
 #include <getopt.h>
 #endif
 
+#ifdef HAVE_NCURSESW
+#include <ncursesw/curses.h>
+#else
 #ifdef HAVE_NCURSES_H
 #include <ncurses.h>
 #else
@@ -56,7 +59,7 @@
 #include <curses.h>
 #endif
 #endif
-
+#endif
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif

--- a/cmatrix.c
+++ b/cmatrix.c
@@ -56,7 +56,6 @@
 #include <curses.h>
 #endif
 #endif
-
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
@@ -261,7 +260,10 @@ void resize_screen(void) {
     char *tty;
     int fd = 0;
     int result = 0;
+    int cols = 0;
+    int lines = 0;
     struct winsize win;
+
 
     tty = ttyname(0);
     if (!tty) {
@@ -271,8 +273,8 @@ void resize_screen(void) {
     result = GetConsoleScreenBufferInfo(hStdHandle, &csbiInfo);
     if (!result)
         return;
-    LINES = csbiInfo.dwSize.Y;
-    COLS = csbiInfo.dwSize.X;
+    lines = csbiInfo.dwSize.Y;
+    cols = csbiInfo.dwSize.X;
 #else
     }
     fd = open(tty, O_RDWR);
@@ -284,21 +286,21 @@ void resize_screen(void) {
         return;
     }
 
-    COLS = win.ws_col;
-    LINES = win.ws_row;
+    cols = win.ws_col;
+    lines = win.ws_row;
 #endif
 
-    if (LINES < 10) {
-        LINES = 10;
+    if (lines < 10) {
+        lines = 10;
     }
-    if (COLS < 10) {
-        COLS = 10;
+    if (cols < 10) {
+        cols = 10;
     }
 
 #ifdef HAVE_RESIZETERM
-    resizeterm(LINES, COLS);
+    resizeterm(lines, cols);
 #ifdef HAVE_WRESIZE
-    if (wresize(stdscr, LINES, COLS) == ERR) {
+    if (wresize(stdscr, lines, cols) == ERR) {
         c_die("Cannot resize window!");
     }
 #endif /* HAVE_WRESIZE */

--- a/cmatrix.c
+++ b/cmatrix.c
@@ -56,6 +56,7 @@
 #include <curses.h>
 #endif
 #endif
+
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,7 @@ fi
 
 if eval "test x$CURSES_LIB_NAME = x"
 then
-    AC_CHECK_LIB(termcap, tgetent, CURSES_LIB="-ltermcap" CURSES_LIB_NAME=termcap)q
+    AC_CHECK_LIB(termcap, tgetent, CURSES_LIB="-ltermcap" CURSES_LIB_NAME=termcap)
 fi
 
 if eval "test x$CURSES_LIB_NAME = x"

--- a/configure.ac
+++ b/configure.ac
@@ -189,7 +189,7 @@ fi
 
 dnl Parse any configure options
 
-LIBS="$LIBS $CURSES_LIB"
+LIBS="$LIBS $CURSES_LIB $TERMCAP_LIB"
 AC_ARG_ENABLE(debug, [  --enable-debug          Enable debugging (def disabled)],)
 AM_CONDITIONAL([MATRIX_FONTS], [test x$enable_fonts = xtrue])
 

--- a/configure.ac
+++ b/configure.ac
@@ -21,11 +21,11 @@ AC_PROG_MAKE_SET
 
 
 dnl Checks for header files.
-AC_HEADER_STDC
+AC_PROG_EGREP
 AC_CHECK_HEADERS(fcntl.h sys/ioctl.h unistd.h termios.h termio.h getopt.h)
 
 dnl Checks for library functions.
-AC_DIAGNOSE([obsolete],[your code may safely assume C89 semantics that RETSIGTYPE is void.
+m4_warn([obsolete],[your code may safely assume C89 semantics that RETSIGTYPE is void.
 Remove this warning and the `AC_CACHE_CHECK' when you adjust the code.])dnl
 AC_CACHE_CHECK([return type of signal handlers],[ac_cv_type_signal],[AC_COMPILE_IFELSE(
 [AC_LANG_PROGRAM([#include <sys/types.h>

--- a/configure.ac
+++ b/configure.ac
@@ -19,9 +19,6 @@ AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 
-dnl Checks for libraries.
-dnl Replace `main' with a function in -lncurses:
-AC_CHECK_LIB(ncurses, main)
 
 dnl Checks for header files.
 AC_HEADER_STDC
@@ -34,8 +31,14 @@ AC_CHECK_FUNCS(putenv)
 dnl Checks for libraries.
 AC_CHECK_HEADERS(curses.h ncurses.h)
 
+
 CURSES_LIB_NAME=""
-AC_CHECK_LIB(ncurses, tgetent, CURSES_LIB="-lncurses" CURSES_LIB_NAME=ncurses)
+AC_CHECK_LIB(ncursesw, tgetent, CURSES_LIB="-lncursesw" CURSES_LIB_NAME=ncursesw)
+
+if eval "test x$CURSES_LIB_NAME = x"
+then
+    AC_CHECK_LIB(ncurses, tgetent, CURSES_LIB="-lncurses" CURSES_LIB_NAME=ncurses)
+fi
 
 if eval "test x$CURSES_LIB_NAME = x"
 then
@@ -49,7 +52,7 @@ fi
 
 if eval "test x$CURSES_LIB_NAME = x"
 then
-    AC_CHECK_LIB(termcap, tgetent, CURSES_LIB="-ltermcap" CURSES_LIB_NAME=termcap)
+    AC_CHECK_LIB(termcap, tgetent, CURSES_LIB="-ltermcap" CURSES_LIB_NAME=termcap)q
 fi
 
 if eval "test x$CURSES_LIB_NAME = x"
@@ -65,13 +68,16 @@ then
 *** errors compiling cmatrix.])
 else
     AC_MSG_RESULT("Using $CURSES_LIB_NAME as the termcap library")
+    if eval "test $CURSES_LIB_NAME = ncursesw"
+    then
+        AC_CHECK_LIB([$CURSES_LIB_NAME], addwstr, [AC_DEFINE(HAVE_NCURSESW)])
+    fi
 fi
 
 AC_CHECK_LIB($CURSES_LIB_NAME, use_default_colors,
 	 AC_DEFINE(HAVE_USE_DEFAULT_COLORS))
 AC_CHECK_LIB($CURSES_LIB_NAME, resizeterm, [AC_DEFINE(HAVE_RESIZETERM)])
 AC_CHECK_LIB([$CURSES_LIB_NAME], wresize, [AC_DEFINE(HAVE_WRESIZE)])
-
 
 dnl Only change gcc options if we are using gcc.
 if test "$ac_cv_prog_CC" = gcc -o "$ac_cv_prog_CC" = g++; then
@@ -115,10 +121,11 @@ if test "x$enable_fonts" != xfalse; then
        if test x$SETFONT != x -o x$SETFONT != x'"$SETFONT"'; then
 
 	  dnl Now look for the console fonts directory
-	  AC_CHECK_FILES([/usr/lib/kbd/consolefonts /usr/share/consolefonts])
+	  AC_CHECK_FILES([/usr/lib/kbd/consolefonts /usr/share/consolefonts /usr/share/kbd/consolefonts])
 
 	  if test "x$ac_cv_file__usr_lib_kbd_consolefonts" = "xno"; then
 	      if test "x$ac_cv_file__usr_share_consolefonts" = "xno"; then
+	          if test "x$ac_cv_file__usr_share_kbd_consolefonts" = "xno"; then
 		  AC_MSG_WARN([
 
 *** You do not appear to have a consolefonts directory in a standard location
@@ -128,6 +135,7 @@ if test "x$enable_fonts" != xfalse; then
 *** matrix console font (and the -l command line switch) unless the font
 *** is located in your current directory when you run CMatrix.
 ])
+            fi
 	      fi
 	  fi
        fi
@@ -168,5 +176,6 @@ AH_TEMPLATE([HAVE_SETFONT], [Define this if you have the linux setfont program])
 AH_TEMPLATE([HAVE_WRESIZE], [Define this if you have the wresize function in your ncurses-type library])
 AH_TEMPLATE([HAVE_RESIZETERM], [Define this if you have the resizeterm function in your ncurses-type library])
 AH_TEMPLATE([USE_TIOCSTI], [Define this if you want a character you pressed in the screensaver mode to retain in the terminal])
+AH_TEMPLATE([HAVE_NCURSESW], [Define this if you have the ncursesw library])
 
 AC_OUTPUT(Makefile cmatrix.spec)

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT([cmatrix], [2.0], [abishekvashok@gmail.com])
+AC_INIT([cmatrix],[2.0],[abishekvashok@gmail.com])
 AC_CONFIG_SRCDIR([cmatrix.c])
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE
 
 AC_CANONICAL_HOST
@@ -25,49 +25,78 @@ AC_HEADER_STDC
 AC_CHECK_HEADERS(fcntl.h sys/ioctl.h unistd.h termios.h termio.h getopt.h)
 
 dnl Checks for library functions.
-AC_TYPE_SIGNAL
+AC_DIAGNOSE([obsolete],[your code may safely assume C89 semantics that RETSIGTYPE is void.
+Remove this warning and the `AC_CACHE_CHECK' when you adjust the code.])dnl
+AC_CACHE_CHECK([return type of signal handlers],[ac_cv_type_signal],[AC_COMPILE_IFELSE(
+[AC_LANG_PROGRAM([#include <sys/types.h>
+#include <signal.h>
+],
+		 [return *(signal (0, 0)) (0) == 1;])],
+		   [ac_cv_type_signal=int],
+		   [ac_cv_type_signal=void])])
+AC_DEFINE_UNQUOTED([RETSIGTYPE],[$ac_cv_type_signal],[Define as the return type of signal handlers
+		    (`int' or `void').])
+
 AC_CHECK_FUNCS(putenv)
 
 dnl Checks for libraries.
 AC_CHECK_HEADERS(curses.h ncurses.h)
 
 
-CURSES_LIB_NAME=""
-AC_CHECK_LIB(ncursesw, tgetent, CURSES_LIB="-lncursesw" CURSES_LIB_NAME=ncursesw)
+TERMCAP_LIB_NAME=""
+AC_CHECK_LIB(ncursesw, tgetent, TERMCAP_LIB="-lncursesw" TERMCAP_LIB_NAME=ncursesw)
 
-if eval "test x$CURSES_LIB_NAME = x"
+if eval "test x$TERMCAP_LIB_NAME = x"
 then
-    AC_CHECK_LIB(ncurses, tgetent, CURSES_LIB="-lncurses" CURSES_LIB_NAME=ncurses)
+    AC_CHECK_LIB(ncurses, tgetent, TERMCAP_LIB="-lncurses" TERMCAP_LIB_NAME=ncurses)
 fi
 
-if eval "test x$CURSES_LIB_NAME = x"
+if eval "test x$TERMCAP_LIB_NAME = x"
 then
-    AC_CHECK_LIB(curses, tgetent, CURSES_LIB="-lcurses" CURSES_LIB_NAME=curses)
+    AC_CHECK_LIB(curses, tgetent, TERMCAP_LIB="-lcurses" TERMCAP_LIB_NAME=curses)
 fi
 
-if eval "test x$CURSES_LIB_NAME = x"
+if eval "test x$TERMCAP_LIB_NAME = x"
 then
-    AC_CHECK_LIB(pdcurses, initscr, CURSES_LIB="-lpdcurses" CURSES_LIB_NAME=pdcurses)
+    AC_CHECK_LIB(pdcurses, initscr, TERMCAP_LIB="-lpdcurses" TERMCAP_LIB_NAME=pdcurses)
 fi
 
-if eval "test x$CURSES_LIB_NAME = x"
+if eval "test x$TERMCAP_LIB_NAME = x"
 then
-    AC_CHECK_LIB(termcap, tgetent, CURSES_LIB="-ltermcap" CURSES_LIB_NAME=termcap)
+    AC_CHECK_LIB(termcap, tgetent, TERMCAP_LIB="-ltermcap" TERMCAP_LIB_NAME=termcap)
 fi
 
-if eval "test x$CURSES_LIB_NAME = x"
+if eval "test x$TERMCAP_LIB_NAME = x"
 then
-    AC_CHECK_LIB(tinfo, tgetent, CURSES_LIB="-ltinfo" CURSES_LIB_NAME=tinfo)
+    AC_CHECK_LIB(tinfo, tgetent, TERMCAP_LIB="-ltinfo" TERMCAP_LIB_NAME=tinfo)
 fi
 
-if eval "test x$CURSES_LIB_NAME = x"
+if eval "test x$TERMCAP_LIB_NAME = x"
 then
     AC_MSG_WARN([
 *** No termcap lib available, consider getting the official ncurses
 *** distribution from ftp://ftp.gnu.org/pub/gnu/ncurses if you get
 *** errors compiling cmatrix.])
 else
-    AC_MSG_RESULT("Using $CURSES_LIB_NAME as the termcap library")
+    AC_MSG_RESULT(Using $TERMCAP_LIB_NAME as the termcap library)
+fi
+
+CURSES_LIB_NAME=""
+AC_CHECK_LIB(ncursesw, addwstr, CURSES_LIB="-lncursesw" CURSES_LIB_NAME=ncursesw)
+
+if eval "test x$CURSES_LIB_NAME = x"
+then
+    AC_CHECK_LIB(ncurses,  addwstr, CURSES_LIB="-lncurses" CURSES_LIB_NAME=ncurses)
+fi
+
+if eval "test x$CURSES_LIB_NAME = x"
+then
+    AC_MSG_WARN([
+*** No curses lib available, consider getting the official ncurses
+*** distribution from ftp://ftp.gnu.org/pub/gnu/ncurses if you get
+*** errors compiling cmatrix.])
+else
+    AC_MSG_RESULT(Using $CURSES_LIB_NAME as the ncurses library)
     if eval "test $CURSES_LIB_NAME = ncursesw"
     then
         AC_CHECK_LIB([$CURSES_LIB_NAME], addwstr, [AC_DEFINE(HAVE_NCURSESW)])
@@ -178,4 +207,5 @@ AH_TEMPLATE([HAVE_RESIZETERM], [Define this if you have the resizeterm function 
 AH_TEMPLATE([USE_TIOCSTI], [Define this if you want a character you pressed in the screensaver mode to retain in the terminal])
 AH_TEMPLATE([HAVE_NCURSESW], [Define this if you have the ncursesw library])
 
-AC_OUTPUT(Makefile cmatrix.spec)
+AC_CONFIG_FILES([Makefile cmatrix.spec])
+AC_OUTPUT


### PR DESCRIPTION
LINES/COLS is no longer a variable in ncurses, but is implemented as functions returning the resp values. Therefore they can not be assigned values anymore.
Fix the code to use local variables instead.
Also fix problems with ncursesw (addwstr) and add logic for font location in openSUSE.